### PR TITLE
handle 0000-00-00 00:00:00 in datetime

### DIFF
--- a/mysql.lisp
+++ b/mysql.lisp
@@ -139,9 +139,12 @@
   (declare (optimize (speed 3) (safety 3))
            (type (or null simple-string) string)
            (type (or null fixnum) len))
-  (when (and string (> (or len (length string)) 0))
-    (+ (string-to-date (subseq string 0 10))
-       (string-to-seconds (subseq string 11)))))
+  (cond
+    ((equal "0000-00-00 00:00:00" string)
+     nil)
+    ((and string (> (or len (length string)) 0))
+     (+ (string-to-date (subseq string 0 10))
+        (string-to-seconds (subseq string 11))))))
 
 (eval-when (:load-toplevel)
   (mapcar (lambda (map)

--- a/test.lisp
+++ b/test.lisp
@@ -91,6 +91,7 @@
 (deftest test-string-to-universal-time ()
   (is (eq nil (string-to-universal-time nil)))
   (is (eq nil (string-to-universal-time "")))
+  (is (eq nil (string-to-universal-time "0000-00-00 00:00:00")))
   (is (eql 1
 	  (- (string-to-universal-time "2009-01-01 00:00:00")
 	     (string-to-universal-time "2008-12-31 23:59:59")))))


### PR DESCRIPTION
`string-to-universaltime` do not handle "0000-00-00 00:00:00" which is treated as null in mysql.