### PR TITLE
Add libmysqlclient library name suggestion for OSX.

### DIFF
--- a/system.lisp
+++ b/system.lisp
@@ -69,6 +69,7 @@
 (in-package "CL-MYSQL-SYSTEM")
 
 (define-foreign-library libmysqlclient
+  (:darwin (:or "libmysqlclient.20.dylib" "libmysqlclient.dylib"))
   ((:not :windows) (:default "libmysqlclient_r"))
   (:windows (:default "libmysql")))
 


### PR DESCRIPTION
I added the library names that I at least have on my mac. The default foreign library name was not found. This now works.