### PR TITLE
Fix the conversion of a datetime string into a universal time.

### DIFF
--- a/mysql.lisp
+++ b/mysql.lisp
@@ -112,7 +112,7 @@
       (unless (or (zerop y)
                   (zerop m)
                   (zerop d))
-        (encode-universal-time 0 0 0 d m y 0)))))
+        (encode-universal-time 0 0 0 d m y)))))
 
 (defun string-to-seconds (string &optional len)
   "Fairly ugly function to turn MySQL TIME duration into an integer representation.


### PR DESCRIPTION
Should not specify timezone (0, GMT) for encode-universal-time at string-to-date for using the system one.