### PR TITLE
fix process-row so cl-mysql works in Windows x64

### DIFF
--- a/mysql.lisp
+++ b/mysql.lisp
@@ -365,7 +365,7 @@
     (loop for i of-type fixnum from 0 to (* num-fields int-size) by int-size
        for f of-type list in field-names-and-types
        collect (extract-field row i
-			      (mem-ref mysql-lens :unsigned-long (/ i int-size)) type-map f))))
+			      (mem-aref mysql-lens :unsigned-long (/ i int-size)) type-map f))))
 
 
 

--- a/mysql.lisp
+++ b/mysql.lisp
@@ -360,12 +360,12 @@
   (declare (optimize (speed 3) (safety 3))
 	   (type (integer 0 65536) num-fields))
   (let* ((mysql-lens (mysql-fetch-lengths mysql-res))
-         (int-size (foreign-type-size :long)))
+         (int-size (foreign-type-size :pointer)))
     (declare (type (integer 0 16) int-size))
     (loop for i of-type fixnum from 0 to (* num-fields int-size) by int-size
        for f of-type list in field-names-and-types
        collect (extract-field row i
-			      (mem-ref mysql-lens :unsigned-long i) type-map f))))
+			      (mem-ref mysql-lens :unsigned-long (/ i int-size)) type-map f))))
 
 
 


### PR DESCRIPTION
I might have a fix for issue https://github.com/hackinghat/cl-mysql/issues/11
If we take a look at `process-row` in mysql.lisp:
https://github.com/hackinghat/cl-mysql/blob/76b570c1119de77f53f5f293f03ce32f312a89a9/mysql.lisp#L359-L368

`int-size` needs to be 8 on win64, but `(foreign-type-size :long)` is 4 on win64 (and 8 on x64 linux)
So I replaced it with `(foreign-type-size :pointer)` which should be 8 on windows and linux x64, and 4 in 32 bit, which is what we want.

However, this now means that the value passed in `i`  to `(mem-ref mysql-lens ...)` is incorrect.
So I replaced `mem-ref` with `mem-aref` which accesses the memory in an array-like fashion (index = 0,1 etc instead of ptr lengths) and divided `i` by `int-size` to step it down.

This works with my test db in Windows 10 x64 and Arch Linux.

I'm only a beginner with Lisp, so let me know if I've overlooked something.