### PR TITLE
update for modern versions of libmysqlclient

### DIFF
--- a/system.lisp
+++ b/system.lisp
@@ -70,7 +70,7 @@
 
 (define-foreign-library libmysqlclient
   (:darwin (:or "libmysqlclient.20.dylib" "libmysqlclient.dylib"))
-  ((:not :windows) (:default "libmysqlclient_r"))
+  ((:not :windows) (:or (:default "libmysqlclient_r") (:default "libmysqlclient")))
   (:windows (:default "libmysql")))
 
 (use-foreign-library libmysqlclient)


### PR DESCRIPTION
modern versions of libmysqlclient are all threadsafe and many linux distributions don't have a libmysqlclient_r symlink anymore